### PR TITLE
feat: change cards ui

### DIFF
--- a/app/card/BuildingCard.tsx
+++ b/app/card/BuildingCard.tsx
@@ -20,6 +20,7 @@ type BuildingCardProps = {
   loading: boolean;
   onClickCard: () => void;
 };
+
 export const BuildingCard: React.FC<BuildingCardProps> = ({
   building,
   emptys,
@@ -32,51 +33,18 @@ export const BuildingCard: React.FC<BuildingCardProps> = ({
       {loading ? (
         <LoadingCard />
       ) : (
-        <Card sx={{ backgroundColor: "#f5f5f5" }} onClick={onClickCard}>
-          <CardHeader
-            title={<CardTitle title={building} countEmptyRooms={emptys} />}
-          />
-          <CardContent>
-            <CardMedia
-              component={"img"}
-              image={imageBuilding}
-              sx={{ aspectRatio: "5/4" }}
-            />
-          </CardContent>
-          <CardActions sx={cardStyle.cardActions}>
-            {/* Este botón existe solo para el caso en que el usuario no sepa donde apretar, en verdad se usa el onClick del Card*/}
-            <Button sx={{ width: "100%" }} variant="contained">
-              Ver salas
-            </Button>
-          </CardActions>
+        <Card sx={cardStyle.card} onClick={onClickCard}>
+          <CardMedia component="img" image={imageBuilding} sx={cardStyle.img} />
+          <Box sx={cardStyle.boxInfo}>
+            <Typography variant="h4">{building}</Typography>
+            <Typography variant="h6">Salas vacías ahora: {emptys}</Typography>
+          </Box>
         </Card>
       )}
     </Box>
   );
 };
 
-type CardTitleProps = {
-  title: string;
-  countEmptyRooms: number;
-};
-const CardTitle = ({ title, countEmptyRooms }: CardTitleProps) => {
-  return (
-    <Box sx={cardStyle.boxCardTitle}>
-      <Typography variant="h4">{title}</Typography>
-      <Typography
-        variant="h6"
-        sx={{
-          mt: { sm: 1, md: 1 },
-        }}
-      >
-        Salas vacías ahora: {countEmptyRooms}
-      </Typography>
-    </Box>
-  );
-};
-
-// Este componente no tiene ningún brillo
-// Es la copia de BuildingCard (tanto en estilo como estructura) pero con un skeleton para el loading
 const LoadingCard: React.FC = () => {
   return (
     <Card sx={{ minWidth: "80%" }}>

--- a/app/card/buildingCardStyle.tsx
+++ b/app/card/buildingCardStyle.tsx
@@ -9,6 +9,35 @@ export const cardStyle: Record<string, SxProps<Theme> | undefined> = {
     justifyContent: "center",
     display: "flex",
   },
+  boxInfo: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: "rgba(0, 0, 0, 0.4)",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "white",
+  },
+  card: {
+    position: "relative",
+    backgroundColor: "#f5f5f5",
+    cursor: "pointer",
+    overflow: "hidden",
+    height: "80vh",
+    "&:hover img": {
+      transform: "scale(1.1)",
+      transition: "transform 0.3s ease-in-out",
+    },
+  },
+  img: {
+    aspectRatio: "5/4",
+    height: "100%",
+    transition: "transform 0.3s ease-in-out", // Transición suave del zoom
+  },
   cardActions: {
     display: "flex",
     flexDirection: "column",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,13 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <Typography
-          sx={{ fontWeight: "medium", fontSize: 46, textAlign: "center" }}
+          sx={{
+            fontWeight: "bold",
+            textTransform: "uppercase",
+            marginTop: 2,
+            fontSize: 40,
+            textAlign: "center",
+          }}
         >
           Salas Vacías FIC
         </Typography>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,6 +43,7 @@ export default function RootLayout({
               }}
             />
           </a>
+          (PR's are welcome)
         </footer>
       </body>
     </html>

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -3,6 +3,7 @@
   flex-direction: row;
   align-items: center;
   padding: 0;
+  margin: auto;
 }
 /* Mobile */
 @media (max-width: 990px) {


### PR DESCRIPTION
Se rediseña la UI de las cards. Al hacer hover, se denota el edificio a consultar quedando más limpio.

[Screencast from 16-10-24 13:14:48.webm](https://github.com/user-attachments/assets/a1fae7d3-9944-4d5d-a03a-11798adb7411)
